### PR TITLE
Fix missing typing imports

### DIFF
--- a/openapi_client/models/components_schemas_metadata_error.py
+++ b/openapi_client/models/components_schemas_metadata_error.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 
-from typing import Optional
+from typing import Optional, Dict, Any
 from pydantic import BaseModel, Field, StrictStr
 
 class ComponentsSchemasMetadataError(BaseModel):


### PR DESCRIPTION
## Summary
- fix F821 by importing `Dict` and `Any` for `ComponentsSchemasMetadataError`

## Testing
- `pip install -e .`
- `pip install -r test-requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68753ee0a310832c933f3bc5c3f169a8